### PR TITLE
Switch to maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Implementation of the MicroProfile Reactive Streams Operator specification
 
+-----
+
+**IMPORTANT**: This repository is in _maintenance_ mode. 
+No new features will be implemented. 
+               
+Another implementation of MicroProfile Reactive Streams Operators is available in [Mutiny](https://smallrye.io/smallrye-mutiny).
+It is recommended to switch to this implementation.
+               
+Reactive Converters have been migrated to https://github.com/smallrye/smallrye-reactive-utils.
+               
+If you have any questions, send a message to https://groups.google.com/forum/#!forum/smallrye.
+
+-----
 
 **Documentation:** https://www.smallrye.io/smallrye-reactive-streams-operators/
 

--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -17,6 +17,19 @@ ifdef::basebackend-html[toc::[]]
 :sectnums:
 :sectnumlevels: 4
 
+----
+
+*IMPORTANT*: This project is in _maintenance_ mode.
+No new features will be implemented.
+
+Another implementation of MicroProfile Reactive Streams Operators is available in https://smallrye.io/smallrye-mutiny[Mutiny].
+It is recommended to switch to this implementation.
+
+Reactive Converters have been migrated to https://github.com/smallrye/smallrye-reactive-utils.
+
+If you have any questions, send a message to the https://groups.google.com/forum/#!forum/smallrye[smallrye group].
+
+----
 
 include::./intro.adoc[]
 include::./getting-started.adoc[]


### PR DESCRIPTION
This implementation of reactive streams operators is now in maintenance mode. 

This PR adds some text indicating the new status and where another implementation can be found.